### PR TITLE
Restrict visibility of CellRef(Mut)::{flag, value} to crate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.0 (unreleased)
+
+* Restrict visibility to `CellRef(Mut)::{flag, value}` to crate. ([#5], [#6])
+
+[#5]: https://github.com/azriel91/rt_ref/issues/5
+[#6]: https://github.com/azriel91/rt_ref/pull/6
+
 ## 0.1.3 (2022-07-14)
 
 * Limit number of `CellRef` references to `isize::MAX`, as it wouldn't realistically fit into memory. ([#1], [#3])

--- a/src/cell_ref.rs
+++ b/src/cell_ref.rs
@@ -14,8 +14,8 @@ pub struct CellRef<'a, T>
 where
     T: ?Sized + 'a,
 {
-    pub flag: &'a AtomicUsize,
-    pub value: &'a T,
+    pub(crate) flag: &'a AtomicUsize,
+    pub(crate) value: &'a T,
 }
 
 /// Cast max `isize` as `usize`, so we don't have to do it in multiple places.

--- a/src/cell_ref_mut.rs
+++ b/src/cell_ref_mut.rs
@@ -12,8 +12,8 @@ pub struct CellRefMut<'a, T>
 where
     T: ?Sized + 'a,
 {
-    pub flag: &'a AtomicUsize,
-    pub value: &'a mut T,
+    pub(crate) flag: &'a AtomicUsize,
+    pub(crate) value: &'a mut T,
 }
 
 impl<'a, T> CellRefMut<'a, T>


### PR DESCRIPTION
Fixes #5 